### PR TITLE
Removed 'git add' from lintstagedrc

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,8 +1,7 @@
 {
     "linters": {
       "*.js": [
-        "eslint",
-        "git add"
+        "eslint"
       ]
     }
 }


### PR DESCRIPTION
Doing a 'git add' in the linting stage is preventing atomic commits.