### PR TITLE
Trying relative paths in package.json of students and instructors pac…

### DIFF
--- a/packages/instructors/package.json
+++ b/packages/instructors/package.json
@@ -24,7 +24,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.0",
-    "shared-components": "^1.0.0"
+    "shared-components": "file:../shared-components"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/students/package.json
+++ b/packages/students/package.json
@@ -26,7 +26,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.0",
-    "shared-components": "^1.0.0",
+    "shared-components": "file:../shared-components",
     "validator": "^10.8.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8639,6 +8639,15 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+"shared-components@file:packages/shared-components":
+  version "1.0.0"
+  dependencies:
+    "@material-ui/core" "^3.2.2"
+    classnames "^2.2.6"
+    prop-types "^15.6.2"
+    react "^16.5.2"
+    react-dom "^16.5.2"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
…kages to get around the 'No matching version found for shared-components error' when deploying to heroku